### PR TITLE
Add stat selection dropdowns for player output

### DIFF
--- a/app.py
+++ b/app.py
@@ -12,20 +12,46 @@ from flask_cors import CORS
 app = Flask(__name__)
 CORS(app)
 
-PLAYER_STAT_TITLES = [
-    "Games Played",
-    "Goals",
-    "Assists",
-    "Points",
-    "PIM",
-    "Position"
-]
+def resolve_player_stats(team_id, player_number, season_stats_flag, game_id=None):
+    """Fetch player stats based on the requested context."""
+    if season_stats_flag:
+        return single_player_stats(team_id, player_number)
+
+    if game_id is None:
+        return None
+
+    return single_player_stats_game(game_id, team_id, player_number)
 
 
 @app.route('/player/stats-options')
 def player_stat_options():
-    """Return a list of player stat titles that can be selected."""
-    return jsonify({"stats": PLAYER_STAT_TITLES})
+    """Return a list of available stat titles for a specific player."""
+    team_id = request.args.get('team_id')
+    player_number = request.args.get('player_number')
+    game_id = request.args.get('game_id')
+    season_stats_flag = request.args.get('season_stats', 'false').lower() == 'true'
+
+    if not team_id or not player_number:
+        return jsonify({"error": "Missing team_id or player_number"}), 400
+
+    if not season_stats_flag and not game_id:
+        return jsonify({"error": "Missing game_id for game stats"}), 400
+
+    player_stats = resolve_player_stats(team_id, player_number, season_stats_flag, game_id)
+
+    if isinstance(player_stats, tuple):
+        return player_stats
+
+    if not player_stats:
+        return jsonify({"stats": []})
+
+    base_fields = {"First Name", "Last Name", "Player Number"}
+    meta_fields = {"Logo", "header", "Color", "Color-s"}
+    excluded_fields = base_fields | meta_fields
+
+    stat_titles = sorted([key for key in player_stats.keys() if key not in excluded_fields])
+
+    return jsonify({"stats": stat_titles})
 
 @app.route('/')
 def hello_world():  # put application's code here
@@ -370,18 +396,20 @@ def output():
         if player_number is None:
             return jsonify({"error": "Missing player_number"}), 400
 
-        season_stats = request.args.get('season_stats')
+        season_stats_flag = request.args.get('season_stats', 'false').lower() == 'true'
         game_id = request.args.get('game_id')
-        print(season_stats)
+        print(season_stats_flag)
         print(game_id)
-        if season_stats == 'true':
-            player_stats = single_player_stats(team_id, player_number)
-        else:
-            player_stats = single_player_stats_game(game_id, team_id, player_number)
-            print('Debug')
 
+        if not season_stats_flag and game_id is None:
+            return jsonify({"error": "Missing game_id for game stats"}), 400
+
+        player_stats = resolve_player_stats(team_id, player_number, season_stats_flag, game_id)
 
         print(player_stats)
+
+        if isinstance(player_stats, tuple):
+            return player_stats
 
         if player_stats is None:
             return jsonify({"error": "Unable to fetch player stats"}), 500

--- a/app.py
+++ b/app.py
@@ -12,6 +12,21 @@ from flask_cors import CORS
 app = Flask(__name__)
 CORS(app)
 
+PLAYER_STAT_TITLES = [
+    "Games Played",
+    "Goals",
+    "Assists",
+    "Points",
+    "PIM",
+    "Position"
+]
+
+
+@app.route('/player/stats-options')
+def player_stat_options():
+    """Return a list of player stat titles that can be selected."""
+    return jsonify({"stats": PLAYER_STAT_TITLES})
+
 @app.route('/')
 def hello_world():  # put application's code here
     return 'Hello World!'
@@ -367,6 +382,24 @@ def output():
 
 
         print(player_stats)
+
+        if player_stats is None:
+            return jsonify({"error": "Unable to fetch player stats"}), 500
+
+        selected_stats = request.args.getlist('stats')
+        if selected_stats:
+            base_fields = ["First Name", "Last Name", "Player Number"]
+            filtered_stats = {}
+            for key in base_fields:
+                if key in player_stats:
+                    filtered_stats[key] = player_stats[key]
+
+            for stat in selected_stats:
+                if stat in player_stats:
+                    filtered_stats[stat] = player_stats[stat]
+
+            if filtered_stats:
+                player_stats = filtered_stats
 
         writer = csv.DictWriter(output, fieldnames=player_stats.keys())
 

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -2,6 +2,43 @@ const teamSelect = document.getElementById("team-select");
 const gameId = document.querySelector('meta[name="game_id"]').getAttribute('content');
 console.log("Game ID:", gameId);
 let seasonStats = false;
+const statSelects = Array.from(document.querySelectorAll('.stat-select'));
+
+async function fetchStatOptions() {
+    const url = 'http://localhost:5000/player/stats-options';
+    try {
+        const response = await fetch(url);
+        if (!response.ok) {
+            console.error('Failed to fetch stat options:', response.statusText);
+            return;
+        }
+
+        const data = await response.json();
+        const stats = data.stats || [];
+        populateStatSelects(stats);
+    } catch (error) {
+        console.error('Error fetching stat options:', error);
+    }
+}
+
+function populateStatSelects(stats) {
+    statSelects.forEach((select) => {
+        select.innerHTML = '';
+        const placeholderOption = document.createElement('option');
+        placeholderOption.value = '';
+        placeholderOption.textContent = 'Select a stat';
+        select.appendChild(placeholderOption);
+
+        stats.forEach((stat) => {
+            const option = document.createElement('option');
+            option.value = stat;
+            option.textContent = stat;
+            select.appendChild(option);
+        });
+    });
+}
+
+fetchStatOptions();
 
 
 //teamSelect.addEventListener("change", SetPlayers())
@@ -140,8 +177,20 @@ const sendButton = document.getElementById("player-send-button")
 sendButton.addEventListener("click", function(e){
     let playerNumber = playerSelect.options[playerSelect.selectedIndex].value;
     let teamId = teamSelect.options[teamSelect.selectedIndex].value;
+    const selectedStats = statSelects
+        .map((select) => select.value)
+        .filter((value) => value !== '');
 
-    const url = `http://127.0.0.1:5000/output/player?team_id=${teamId}&player_number=${playerNumber}&game_id=${gameId}&season_stats=${seasonStats}`
+    const params = new URLSearchParams({
+        team_id: teamId,
+        player_number: playerNumber,
+        game_id: gameId,
+        season_stats: seasonStats
+    });
+
+    selectedStats.forEach((stat) => params.append('stats', stat));
+
+    const url = `http://127.0.0.1:5000/output/player?${params.toString()}`
 
     fetch(url, {
     method: "POST",

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -68,7 +68,7 @@ async function SetPlayers() {
     const selectedTeamId = teamSelect.value;
     console.log(selectedTeamId);
 
-    const teamStatus = await checkIfHomeTeam(gameId, selectedTeamId);
+    const teamStatus = await checkIfHomeTeam(selectedTeamId, gameId);
 
     if (!teamStatus) {
         return;

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -4,23 +4,6 @@ console.log("Game ID:", gameId);
 let seasonStats = false;
 const statSelects = Array.from(document.querySelectorAll('.stat-select'));
 
-async function fetchStatOptions() {
-    const url = 'http://localhost:5000/player/stats-options';
-    try {
-        const response = await fetch(url);
-        if (!response.ok) {
-            console.error('Failed to fetch stat options:', response.statusText);
-            return;
-        }
-
-        const data = await response.json();
-        const stats = data.stats || [];
-        populateStatSelects(stats);
-    } catch (error) {
-        console.error('Error fetching stat options:', error);
-    }
-}
-
 function populateStatSelects(stats) {
     statSelects.forEach((select) => {
         select.innerHTML = '';
@@ -38,74 +21,95 @@ function populateStatSelects(stats) {
     });
 }
 
-fetchStatOptions();
+function clearStatSelects() {
+    populateStatSelects([]);
+}
 
+async function fetchStatOptionsForSelection() {
+    const teamId = teamSelect.value;
+    const playerNumber = playerSelect.value;
 
-//teamSelect.addEventListener("change", SetPlayers())
-
-teamSelect.addEventListener("change", function SetPlayers (event) {
-    console.log(teamSelect.value);
-
-    checkIfHomeTeam(teamSelect.value, gameId).then(r => {
-    if (r) {
-        if (r.is_home_team) {
-            console.log("Home Team");
-            getRosters(gameId, 'True').then(response => {
-                if (response) {
-                    console.log(response);
-
-                    const selectElement = document.getElementById('player-select');
-                    if (!selectElement) {
-                        console.error('Select element not found!');
-                        return;
-                    }
-
-                    // Clear existing options
-                    selectElement.innerHTML = '';
-
-                    // Sort players by number
-                    response.sort((a, b) => a.number - b.number);
-
-                    // Add players as options
-                    response.forEach(player => {
-                        const option = document.createElement('option');
-                        option.value = player.number;
-                        option.textContent = `${player.number} - ${player.name}`;
-                        selectElement.appendChild(option);
-                    });
-                }
-            });
-        } else {
-            getRosters(gameId, 'False').then(response => {
-                if (response) {
-                    console.log(response);
-
-                    const selectElement = document.getElementById('player-select');
-                    if (!selectElement) {
-                        console.error('Select element not found!');
-                        return;
-                    }
-
-                    // Clear existing options
-                    selectElement.innerHTML = '';
-
-                    // Sort players by number
-                    response.sort((a, b) => a.number - b.number);
-
-                    // Add players as options
-                    response.forEach(player => {
-                        const option = document.createElement('option');
-                        option.value = player.number;
-                        option.textContent = `${player.number} - ${player.name}`;
-                        selectElement.appendChild(option);
-                    });
-                }
-            });
-        }
+    if (!teamId || !playerNumber) {
+        clearStatSelects();
+        return;
     }
-});
 
-})
+    const params = new URLSearchParams({
+        team_id: teamId,
+        player_number: playerNumber,
+        season_stats: seasonStats ? 'true' : 'false',
+    });
+
+    if (gameId) {
+        params.append('game_id', gameId);
+    }
+
+    const url = `http://localhost:5000/player/stats-options?${params.toString()}`;
+
+    try {
+        const response = await fetch(url);
+        if (!response.ok) {
+            console.error('Failed to fetch stat options:', response.statusText);
+            clearStatSelects();
+            return;
+        }
+
+        const data = await response.json();
+        const stats = data.stats || [];
+        populateStatSelects(stats);
+    } catch (error) {
+        console.error('Error fetching stat options:', error);
+        clearStatSelects();
+    }
+}
+
+
+async function SetPlayers() {
+    const selectedTeamId = teamSelect.value;
+    console.log(selectedTeamId);
+
+    const teamStatus = await checkIfHomeTeam(gameId, selectedTeamId);
+
+    if (!teamStatus) {
+        return;
+    }
+
+    const roster = await getRosters(gameId, teamStatus.is_home_team ? 'True' : 'False');
+
+    if (!roster) {
+        return;
+    }
+
+    const selectElement = document.getElementById('player-select');
+    if (!selectElement) {
+        console.error('Select element not found!');
+        return;
+    }
+
+    selectElement.innerHTML = '';
+
+    roster.sort((a, b) => a.number - b.number);
+
+    roster.forEach(player => {
+        const option = document.createElement('option');
+        option.value = player.number;
+        option.textContent = `${player.number} - ${player.name}`;
+        selectElement.appendChild(option);
+    });
+
+    if (selectElement.options.length > 0) {
+        selectElement.selectedIndex = 0;
+        selectElement.dispatchEvent(new Event('change'));
+    } else {
+        const nameElement = document.getElementById('name');
+        if (nameElement) {
+            nameElement.textContent = 'Name: ';
+        }
+        clearStatSelects();
+    }
+}
+
+teamSelect.addEventListener('change', SetPlayers);
 
 
 async function checkIfHomeTeam(gameId, teamId) {
@@ -150,15 +154,22 @@ async function getRosters(gameId, homeTeam) {
     }
 }
 
-const playerSelect = document.getElementById("player-select")
+const playerSelect = document.getElementById("player-select");
 
 playerSelect.addEventListener("change", function(event){
     const selectedPlayer = playerSelect.options[playerSelect.selectedIndex];
-    const nameElement = document.getElementById("name")
-    nameElement.textContent = "Name: " + selectedPlayer.textContent
+    const nameElement = document.getElementById("name");
+
+    if (selectedPlayer) {
+        nameElement.textContent = "Name: " + selectedPlayer.textContent;
+    } else {
+        nameElement.textContent = "Name: ";
+    }
+
+    fetchStatOptionsForSelection();
 
     console.log("Player: " + selectedPlayer);
-})
+});
 
 const toggle = document.getElementById('toggle');
 
@@ -170,6 +181,8 @@ toggle.addEventListener('change', (event) => {
     console.log('Toggle is OFF');
     seasonStats = true
   }
+
+  fetchStatOptionsForSelection();
 });
 
 const sendButton = document.getElementById("player-send-button")
@@ -185,7 +198,7 @@ sendButton.addEventListener("click", function(e){
         team_id: teamId,
         player_number: playerNumber,
         game_id: gameId,
-        season_stats: seasonStats
+        season_stats: seasonStats ? 'true' : 'false'
     });
 
     selectedStats.forEach((stat) => params.append('stats', stat));
@@ -193,11 +206,11 @@ sendButton.addEventListener("click", function(e){
     const url = `http://127.0.0.1:5000/output/player?${params.toString()}`
 
     fetch(url, {
-    method: "POST",
-    headers: {
-        "Content-Type": "application/json",
-    }, // Convert data object to JSON string
-})
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+        }, // Convert data object to JSON string
+    })
     .then((response) => {
         if (!response.ok) {
             throw new Error(`HTTP error! status: ${response.status}`);
@@ -210,4 +223,6 @@ sendButton.addEventListener("click", function(e){
     .catch((error) => {
         console.error("Error:", error);
     });
-})
+});
+
+SetPlayers();

--- a/templates/index.html
+++ b/templates/index.html
@@ -75,7 +75,40 @@
             </div>
         </div>
     </div>
-    <div id="right" class="inner"></div>
+    <div id="right" class="inner">
+        <div class="box-header">
+            <div class="box-title">
+                <h2>Stat Selection</h2>
+            </div>
+        </div>
+        <div class="box-body" id="stat-selection">
+            <div class="row-box">
+                <select class="cell stat-select" data-select-index="1">
+                    <option value="">Select a stat</option>
+                </select>
+            </div>
+            <div class="row-box">
+                <select class="cell stat-select" data-select-index="2">
+                    <option value="">Select a stat</option>
+                </select>
+            </div>
+            <div class="row-box">
+                <select class="cell stat-select" data-select-index="3">
+                    <option value="">Select a stat</option>
+                </select>
+            </div>
+            <div class="row-box">
+                <select class="cell stat-select" data-select-index="4">
+                    <option value="">Select a stat</option>
+                </select>
+            </div>
+            <div class="row-box">
+                <select class="cell stat-select" data-select-index="5">
+                    <option value="">Select a stat</option>
+                </select>
+            </div>
+        </div>
+    </div>
 </div>
 <script src="/static/js/script.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- add a backend endpoint that returns player stat titles and filters CSV output based on selected stats
- add a stat selection column on the game page and populate the dropdowns from the backend
- include the selected stats in the request to the player output endpoint

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68e52321e0d083249204d60dad736e55